### PR TITLE
ci: Add workflow to automate chart version bump & release

### DIFF
--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -15,13 +15,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          node-version: '14'
+          python-version: '3.x'
 
-      - name: Install dependencies
-        run: npm install
+      - name: Install semver
+        run: |
+          pip install semver
 
       - name: Bump version
         id: bump-version
@@ -30,9 +31,9 @@ jobs:
           N8N_VERSION=$(grep -oP '^appVersion: "\K.*(?=")' n8n/Chart.yaml)
           TEMPLATE_CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -E 'n8n/templates/.*\.yaml' || true)
           if [[ $TEMPLATE_CHANGED ]]; then
-            NEW_VERSION=$(npm version minor --no-git-tag-version)
+            NEW_VERSION=$(python -c "import semver; print(semver.VersionInfo.parse('$CURRENT_VERSION').bump_minor())")
           else
-            NEW_VERSION=$(npm version patch --no-git-tag-version)
+            NEW_VERSION=$(python -c "import semver; print(semver.VersionInfo.parse('$CURRENT_VERSION').bump_patch())")
           fi
           echo "New version: $NEW_VERSION"
           sed -i "s/^version: .*/version: $NEW_VERSION/" n8n/Chart.yaml

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -39,6 +39,7 @@ jobs:
           sed -i "s/^version: .*/version: $NEW_VERSION/" n8n/Chart.yaml
 
       - name: Commit changes
+        if: github.ref == 'refs/heads/main'
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -47,6 +48,7 @@ jobs:
           git push
 
       - name: Create release
+        if: github.ref == 'refs/heads/main'
         uses: actions/create-release@v1
         with:
           tag_name: ${{ steps.bump-version.outputs.NEW_VERSION }}
@@ -55,3 +57,10 @@ jobs:
             Automated release for version ${{ steps.bump-version.outputs.NEW_VERSION }}
           draft: false
           prerelease: false
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        run: |
+          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          COMMENT_BODY="Next version to publish after this PR is merged: $NEW_VERSION"
+          gh pr comment $PR_NUMBER --body "$COMMENT_BODY"

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -1,0 +1,56 @@
+name: CI Version Bump
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Bump version
+        id: bump-version
+        run: |
+          CURRENT_VERSION=$(grep -oP '^version: \K.*' n8n/Chart.yaml)
+          N8N_VERSION=$(grep -oP '^appVersion: "\K.*(?=")' n8n/Chart.yaml)
+          TEMPLATE_CHANGED=$(git diff --name-only HEAD~1 HEAD | grep -E 'n8n/templates/.*\.yaml' || true)
+          if [[ $TEMPLATE_CHANGED ]]; then
+            NEW_VERSION=$(npm version minor --no-git-tag-version)
+          else
+            NEW_VERSION=$(npm version patch --no-git-tag-version)
+          fi
+          echo "New version: $NEW_VERSION"
+          sed -i "s/^version: .*/version: $NEW_VERSION/" n8n/Chart.yaml
+
+      - name: Commit changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add n8n/Chart.yaml
+          git commit -m "ci: bump chart version to $NEW_VERSION"
+          git push
+
+      - name: Create release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.bump-version.outputs.NEW_VERSION }}
+          release_name: Release ${{ steps.bump-version.outputs.NEW_VERSION }}
+          body: |
+            Automated release for version ${{ steps.bump-version.outputs.NEW_VERSION }}
+          draft: false
+          prerelease: false

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -39,6 +39,7 @@ jobs:
           fi
           echo "New version: $NEW_VERSION"
           sed -i "s/^version: .*/version: $NEW_VERSION/" n8n/Chart.yaml
+          echo "::set-output name=NEW_VERSION::$NEW_VERSION"
 
       - name: Commit changes
         if: github.ref == 'refs/heads/main'
@@ -64,6 +65,6 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v3
         with:
+          comment_tag: next_version
           message: |
             Next version to publish after this PR is merged: `${{ steps.bump-version.outputs.NEW_VERSION }}`
-          comment_tag: next_version

--- a/.github/workflows/ci-version-bump.yml
+++ b/.github/workflows/ci-version-bump.yml
@@ -62,7 +62,8 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'
-        run: |
-          PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-          COMMENT_BODY="Next version to publish after this PR is merged: $NEW_VERSION"
-          gh pr comment $PR_NUMBER --body "$COMMENT_BODY"
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            Next version to publish after this PR is merged: `${{ steps.bump-version.outputs.NEW_VERSION }}`
+          comment_tag: next_version

--- a/README.md
+++ b/README.md
@@ -52,14 +52,17 @@ A new workflow has been added to automate chart version bump and release. The wo
 
 * Bumps patch version on n8n major/minor and patch for n8n patch versions.
 * Bumps minor version for template changes.
+* Only pushes version changes on main branch runs.
+* Comments on the next version to publish after a PR merge.
 
 The workflow is triggered on push and pull request events to the `main` branch. It performs the following steps:
 
 1. Checks out the code.
-2. Sets up Node.js environment.
-3. Installs dependencies.
+2. Sets up Python environment.
+3. Installs `python semver`.
 4. Bumps the chart version based on changes.
 5. Commits the changes.
 6. Creates a release.
+7. Comments on the next version to publish after a PR merge.
 
 The version bumping is done for the Helm chart version, not for a Node.js package.

--- a/README.md
+++ b/README.md
@@ -45,3 +45,21 @@ ingress:
 ```
 
 see [values.yaml](./n8n/values.yaml)
+
+## CI Version Bump Workflow
+
+A new workflow has been added to automate chart version bump and release. The workflow is defined in the `.github/workflows/ci-version-bump.yml` file and performs the following actions:
+
+* Bumps patch version on n8n major/minor and patch for n8n patch versions.
+* Bumps minor version for template changes.
+
+The workflow is triggered on push and pull request events to the `main` branch. It performs the following steps:
+
+1. Checks out the code.
+2. Sets up Node.js environment.
+3. Installs dependencies.
+4. Bumps the chart version based on changes.
+5. Commits the changes.
+6. Creates a release.
+
+The version bumping is done for the Helm chart version, not for a Node.js package.

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,10 @@
     {
       "matchPaths": ["n8n/templates/**/*.yaml"],
       "bumpVersion": "minor"
+    },
+    {
+      "matchPaths": ["n8n/Chart.yaml"],
+      "bumpVersion": "patch"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,17 @@
       ]
     }
   ],
-  "bumpVersion": "patch"
+  "bumpVersion": "patch",
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/n8n-io/n8n"],
+      "versioning": "semver",
+      "bumpVersion": "patch"
+    },
+    {
+      "matchPaths": ["n8n/templates/**/*.yaml"],
+      "bumpVersion": "minor"
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #49

Add a new workflow to automate chart version bump and release.

* **New Workflow**: Add `.github/workflows/ci-version-bump.yml` to automate version bumps.
  - Bump patch version on n8n major/minor and patch for n8n patch versions.
  - Bump minor version for template changes.
* **Renovate Configuration**: Update `renovate.json` to include chart version bumping.
  - Add package rules for Docker and template changes.
  - Set bump version to patch for Docker and minor for template changes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/a5r0n/n8n-chart/issues/49?shareId=4c5cc46f-b775-44bc-bd06-799f29ed6e34).