### PR TITLE
chore: bump n8n to 2.25.2 and switch default image to GHCR

### DIFF
--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -32,4 +32,4 @@ version: 0.5.0
 # It is recommended to use it with quotes.
 
 # renovate: image=ghcr.io/n8n-io/n8n
-appVersion: "2.23.1"
+appVersion: "2.25.2"

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -7,7 +7,7 @@
 replicaCount: 1
 
 image:
-  repository: n8nio/n8n
+  repository: ghcr.io/n8n-io/n8n
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
## Summary

- Bumps `appVersion` from `2.23.1` to `2.25.2` (supersedes Renovate PR #88)
- Switches `image.repository` default from `n8nio/n8n` (Docker Hub) to `ghcr.io/n8n-io/n8n` to align with the Renovate tracking source and avoid Docker Hub pull rate limits

## Notable n8n 2.24.0 changes for operators

- **DB migration**: `timestamptz` for data table date columns — runs automatically on startup
- **OTel behavior**: only published workflows are now tracked by default (new default in 2.24)
- **Knowledge Base**: new in-app feature, fully DB-backed, no extra chart config needed

## Test plan

- [ ] Chart installs cleanly with default values (image pulls from GHCR)
- [ ] Existing deployments with `image.repository` overrides are unaffected
- [ ] CI lint + install passes