### PR TITLE
fix: revert image.repository to n8nio/n8n (GHCR only has 0.x tags)

### DIFF
--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -32,4 +32,4 @@ version: 0.5.0
 # It is recommended to use it with quotes.
 
 # renovate: image=ghcr.io/n8n-io/n8n
-appVersion: "2.23.1"
+appVersion: "2.25.2"

--- a/n8n/Chart.yaml
+++ b/n8n/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -7,7 +7,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/n8n-io/n8n
+  repository: n8nio/n8n
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/n8n/values.yaml
+++ b/n8n/values.yaml
@@ -7,7 +7,7 @@
 replicaCount: 1
 
 image:
-  repository: n8nio/n8n
+  repository: ghcr.io/n8n-io/n8n
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
## Problem

PR #91 switched `image.repository` from `n8nio/n8n` to `ghcr.io/n8n-io/n8n`, causing 403 errors on pull. Investigation shows `ghcr.io/n8n-io/n8n` only carries the old `0.x.x` tag series (latest: `0.231.0`) — n8n publishes 2.x releases exclusively on Docker Hub (`n8nio/n8n`).

The `# renovate: image=ghcr.io/n8n-io/n8n` comment in `Chart.yaml` is a Renovate version-tracking hint only; it does not mean the image is pullable from GHCR.

## Fix

Revert `image.repository` back to `n8nio/n8n`.

## Test plan

- [ ] `helm template` renders `n8nio/n8n:2.25.2` by default
- [ ] CI passes